### PR TITLE
Fix StorageService/1 Volume property link format

### DIFF
--- a/Resources/StorageServices/1/index.json
+++ b/Resources/StorageServices/1/index.json
@@ -18,7 +18,7 @@
   "StorageGroups": {"@odata.id": "/redfish/v1/StorageServices/1/StorageGroups"},
   "StoragePools": {"@odata.id": "/redfish/v1/StorageServices/1/StoragePools"},
   "Volumes": {
-    "Members":[{"@odata.id": "/redfish/v1/StorageServices/1/Volumes"}]
+    "@odata.id": "/redfish/v1/StorageServices/1/Volumes"
   },
   "StorageSubsystems": {"@odata.id": "/redfish/v1/StorageServices/1/StorageSubsystems"},
   "Links": {


### PR DESCRIPTION
The Volume property should be a navigation item to a VolumeCollection. For the first StorageService, this was being returned with a Members array of links. This fixes the formatting to match the correct link
being returned with StorageService/2.

Closes: #63