### PR TITLE
Fixed setup.sh script to allow running from custom WORK_DIR

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -181,7 +181,7 @@ $(tput bold)Press Ctrl-C when done.$(tput sgr0)
 EOF
 
 cd "$WORK_DIR"
-"$WORK_DIR"/venv/bin/python emulator.py -port $API_PORT
+./venv/bin/python emulator.py -port $API_PORT
 
 echo ""
 echo "Emulator can be rerun from '$WORK_DIR' by running the command:"


### PR DESCRIPTION
This pull request fixes a bug in the `setup.sh` script that prevented installing and running the emulator from an arbitrary WORK_DIR.

example:
```
./setup.sh -w ./custom_work_dir
```

Signed-off-by: Christian Pinto <christian.pinto@ibm.com>